### PR TITLE
Update the spec file

### DIFF
--- a/csp-billing-adapter-google.spec
+++ b/csp-billing-adapter-google.spec
@@ -15,30 +15,37 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%global skip_python2 1
+%define pythons python3
 Name:           csp-billing-adapter-google
 Version:        0.0.1
 Release:        0
-Summary:        TBD
+Summary:        Implements Google metering hooks for csp-billing-adapter
 License:        Apache-2.0
 URL:            https://github.com/SUSE-Enceladus/%{name}
 Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
+BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
-BuildRequires:  python3-pluggy
-BuildRequires:  python3-google-cloud-iam
-BuildRequires:  csp-billing-adapter
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module pluggy}
+BuildRequires:  %{python_module google-cloud-core}
+BuildRequires:  %{python_module csp-billing-adapter}
 %if %{with test}
-BuildRequires:  python3-pytest
-BuildRequires:  python3-coverage
-BuildRequires:  python3-pytest-cov
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module coverage}
+BuildRequires:  %{python_module pytest-cov}
 %endif
-Requires:       python3-pluggy
-Requires:       python3-google-cloud-iam
-Requires:       csp-billing-adapter
+Requires:       python-setuptools
+Requires:       python-pluggy
+Requires:       python-google-cloud-core
+Requires:       python-csp-billing-adapter
 BuildArch:      noarch
+%python_subpackages
 
 %description
-TBD
+Provides a plugin for csp-billing-adapter to handle
+metering of usage in Google GCP.
 
 %prep
 %autosetup -n %{name}-%{version}
@@ -52,14 +59,13 @@ TBD
 
 %check
 %if %{with test}
-python3 -m pytest --cov=csp_billing_adapter_google
+%pytest
 %endif
 
 %files %{python_files}
 %license LICENSE
 %doc README.md CONTRIBUTING.md
-%{python_sitelib}/%{name}
-%{python_sitelib}/%{name}-%{version}*-info
-%{_bindir}/%{name}
+%{python_sitelib}/csp_billing_adapter_google
+%{python_sitelib}/csp_billing_adapter_google-%{version}*-info
 
 %changelog


### PR DESCRIPTION
Align the spec file with recent changes to the other CSP plugins.

Update the dependent package lists to reflect what is available to install.