### PR TITLE
Add obsoletes to spec file

### DIFF
--- a/csp-billing-adapter-google.spec
+++ b/csp-billing-adapter-google.spec
@@ -42,6 +42,7 @@ Requires:       python-pluggy
 Requires:       python-google-cloud-core
 Requires:       python-csp-billing-adapter
 BuildArch:      noarch
+Obsoletes:      python3-csp-billing-adapter-google < %{version}
 %python_subpackages
 
 %description


### PR DESCRIPTION
The package builds for python 3.## version instead of only python3